### PR TITLE
Fix initialization wait loop

### DIFF
--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -1,7 +1,6 @@
 Make the timeout a property on the WebView (Form and WPF)
 Fix cannot dispose of task while running exception
 Markup and Group cannot call StartWebViewCoreIfPossible because  RequiredStartupPropertiesSet does not check if they are set or not. Also, Markup and Group MUST be set only before the remote web view is created!!
-WaitForInitializationComplete relies on a 5 second delay
 Remove the server from the release package and have user install dotnet tool instead
 Add detailed build instructions for the server
 

--- a/src/RemoteBlazorWebView/RemoteBlazorWebViewWindow.cs
+++ b/src/RemoteBlazorWebView/RemoteBlazorWebViewWindow.cs
@@ -81,20 +81,23 @@ namespace PeakSWC.RemoteWebView
 
         public async Task WaitForInitializationComplete()
         {
-            while(true)
+            while (true)
             {
                 try
                 {
-                    var h = this.WindowHandle;
-                    await Task.Delay(5000);
-                    break;
+                    if (this.WindowHandle != IntPtr.Zero)
+                    {
+                        break;
+                    }
                 }
-                catch (Exception)
+                catch
                 {
-                    await Task.Delay(100);
+                    // Ignore and keep waiting until the handle is available
                 }
+
+                await Task.Delay(100);
             }
-           
+
         }
 
         public Task<Uri?> GetGrpcBaseUriAsync(Uri? serverUri)


### PR DESCRIPTION
## Summary
- fix `WaitForInitializationComplete` so it waits until the Photino window is ready
- remove obsolete TODO entry referencing this issue

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7153804c8320b49b950009a8c59d