### PR TITLE
Fix client cache logging message

### DIFF
--- a/src/RemoteWebViewService/Services/ClientIPCService.cs
+++ b/src/RemoteWebViewService/Services/ClientIPCService.cs
@@ -72,7 +72,7 @@ namespace PeakSWC.RemoteWebView
             if (request.EnableClientCache != null)
             {
                 filesOptions.UseClientCache = request.EnableClientCache.Value;
-                Console.WriteLine($"Server cache enabled = {request.EnableClientCache.Value}");
+                Console.WriteLine($"Client cache enabled = {request.EnableClientCache.Value}");
             }
             
             return Task.FromResult(new Empty());


### PR DESCRIPTION
## Summary
- correct client cache message in ClientIPCService

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7492d9c88320a86bb95fa8442d8f