### PR TITLE
Fix ServerStats atomic double add

### DIFF
--- a/src/RemoteWebViewService/ServerStats.cs
+++ b/src/RemoteWebViewService/ServerStats.cs
@@ -58,8 +58,13 @@ namespace PeakSWC.RemoteWebView
                 }
             }
 
-            // Thread-safe addition for total response time
-            Interlocked.Exchange(ref _totalResponseTime, _totalResponseTime + responseTime);
+            // Atomically add the response time using CompareExchange since Interlocked.Add doesn't support double
+            double initialTotal, newTotal;
+            do
+            {
+                initialTotal = _totalResponseTime;
+                newTotal = initialTotal + responseTime;
+            } while (initialTotal != Interlocked.CompareExchange(ref _totalResponseTime, newTotal, initialTotal));
 
             _responseTimes.Add(responseTime);
 


### PR DESCRIPTION
## Summary
- ensure `_totalResponseTime` is updated atomically using `Interlocked.CompareExchange`
- document why this approach is used in the comment

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d74faf1648320b9d4f66389d21e8e