### PR TITLE
Fix ServiceState disposal race

### DIFF
--- a/src/RemoteWebViewService/ServiceState.cs
+++ b/src/RemoteWebViewService/ServiceState.cs
@@ -45,7 +45,7 @@ namespace PeakSWC.RemoteWebView
 
         public DateTime StartTime { get; } = DateTime.UtcNow;
 
-        private bool _disposed = false;
+        private int _disposed = 0; // 0 = not disposed, 1 = disposed
         private readonly object _disposeLock = new();
 
         public void Cancel()
@@ -68,7 +68,7 @@ namespace PeakSWC.RemoteWebView
 
         protected virtual async ValueTask DisposeAsyncCore()
         {
-            if (_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
                 return;
 
             if (CancellationTokenSource != null)
@@ -128,27 +128,22 @@ namespace PeakSWC.RemoteWebView
                 CancellationTokenSource = null;
             }
 
-            _disposed = true;
+            // Disposal flag already set using Interlocked at the start
         }
 
         protected virtual void Dispose(bool disposing)
         {
-            if (_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
                 return;
 
             lock (_disposeLock)
             {
-                if (_disposed)
-                    return;
-
                 if (disposing)
                 {
-                   
+
                 }
 
                 // Free unmanaged resources here, if any...
-
-                _disposed = true;
             }
         }
 

--- a/src/RemoteWebViewService/ServiceState.cs
+++ b/src/RemoteWebViewService/ServiceState.cs
@@ -46,7 +46,6 @@ namespace PeakSWC.RemoteWebView
         public DateTime StartTime { get; } = DateTime.UtcNow;
 
         private int _disposed = 0; // 0 = not disposed, 1 = disposed
-        private readonly object _disposeLock = new();
 
         public void Cancel()
         {
@@ -136,15 +135,12 @@ namespace PeakSWC.RemoteWebView
             if (Interlocked.Exchange(ref _disposed, 1) == 1)
                 return;
 
-            lock (_disposeLock)
+            if (disposing)
             {
-                if (disposing)
-                {
 
-                }
-
-                // Free unmanaged resources here, if any...
             }
+
+            // Free unmanaged resources here, if any...
         }
 
         public ServiceState(ILogger<RemoteWebViewService> logger, bool enableMirrors)


### PR DESCRIPTION
## Summary
- avoid race in `ServiceState` disposal by interlocking

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d774ede388320a66514c52f6d2c7c