### PR TITLE
Fix test project namespaces

### DIFF
--- a/test/FileSyncServer.Tests/BlazorWebViewFactory.cs
+++ b/test/FileSyncServer.Tests/BlazorWebViewFactory.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using PeakSWC.RemoteBlazorWebView;
 using PeakSWC.RemoteBlazorWebView.Wpf;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public static class BlazorWebViewFactory
     {

--- a/test/FileSyncServer.Tests/BlazorWebViewFormFactory.cs
+++ b/test/FileSyncServer.Tests/BlazorWebViewFormFactory.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using PeakSWC.RemoteBlazorWebView;
 using PeakSWC.RemoteBlazorWebView.WindowsForms;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public static class BlazorWebViewFormFactory
     {

--- a/test/FileSyncServer.Tests/ClientCaching.cs
+++ b/test/FileSyncServer.Tests/ClientCaching.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 using Microsoft.Playwright;
 using System.Net;
 using System.Security.Principal;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 
 namespace FileSyncServer.Tests
 {
@@ -167,6 +167,7 @@ namespace FileSyncServer.Tests
                     // Log the exception or handle accordingly
                 }
             }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/FileSyncServer.Tests/ClientCachingCollection.cs
+++ b/test/FileSyncServer.Tests/ClientCachingCollection.cs
@@ -1,4 +1,6 @@
-﻿[CollectionDefinition("Client caching collection", DisableParallelization = true)]
+namespace FileSyncServer.Tests;
+
+[CollectionDefinition("Client caching collection", DisableParallelization = true)]
 public class ClientCachingCollection : ICollectionFixture<ServerFixture>, ICollectionFixture<ClientFixture>
 {
     // This class has no code, and is never created. Its purpose is simply

--- a/test/FileSyncServer.Tests/ClientFixture.cs
+++ b/test/FileSyncServer.Tests/ClientFixture.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Threading;
 using Xunit;
 
+namespace FileSyncServer.Tests
+{
 public class ClientFixture : IDisposable
 {
     public Process ClientProcess { get; private set; }
@@ -93,5 +95,7 @@ public class ClientFixture : IDisposable
         }
         ClientProcess.Dispose();
         _clientReady.Dispose();
+        GC.SuppressFinalize(this);
     }
+}
 }

--- a/test/FileSyncServer.Tests/ConcurrentRequestsTests .cs
+++ b/test/FileSyncServer.Tests/ConcurrentRequestsTests .cs
@@ -9,10 +9,10 @@ using System.Threading.Tasks;
 using FileSyncServer;
 using FluentAssertions;
 using Microsoft.Playwright;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 using Xunit;
 
-namespace Server
+namespace FileSyncServer.Tests
 {
     [Collection("Server collection")]
     public class ConcurrentRequestsTests

--- a/test/FileSyncServer.Tests/FileFetchingTests.cs
+++ b/test/FileSyncServer.Tests/FileFetchingTests.cs
@@ -7,10 +7,10 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using FileSyncServer;
 using FluentAssertions;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 using Xunit;
 
-namespace Server
+namespace FileSyncServer.Tests
 {
     [Collection("Server collection")]
     public class FileFetchingTests

--- a/test/FileSyncServer.Tests/Home.razor.cs
+++ b/test/FileSyncServer.Tests/Home.razor.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Components;
 using System.Threading.Tasks;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public partial class Home : ComponentBase
     {

--- a/test/FileSyncServer.Tests/LargeFileSetup.cs
+++ b/test/FileSyncServer.Tests/LargeFileSetup.cs
@@ -1,4 +1,6 @@
-﻿public class LargeFileSetup
+namespace FileSyncServer.Tests;
+
+public static class LargeFileSetup
 {
     public static void EnsureLargeFileExists(string filePath, long sizeInBytes)
     {
@@ -6,13 +8,6 @@
         {
             using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
             fs.SetLength(sizeInBytes);
-            // Optionally, write random data
-            // byte[] data = new byte[8192];
-            // new Random().NextBytes(data);
-            // for (long i = 0; i < sizeInBytes; i += data.Length)
-            // {
-            //     fs.Write(data, 0, (int)Math.Min(data.Length, sizeInBytes - i));
-            // }
         }
     }
 }

--- a/test/FileSyncServer.Tests/LoadTest.cs
+++ b/test/FileSyncServer.Tests/LoadTest.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using FileSyncServer;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 namespace FileSyncServer.Tests
 {
     [Collection("Server collection")]

--- a/test/FileSyncServer.Tests/Local/TestLocal.cs
+++ b/test/FileSyncServer.Tests/Local/TestLocal.cs
@@ -3,7 +3,7 @@ using FileSyncServer.Tests.Local;
 using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests.Local
 {
     #region Form
     [Collection("TestLocalBlazorForm")]

--- a/test/FileSyncServer.Tests/PerformanceCollection.cs
+++ b/test/FileSyncServer.Tests/PerformanceCollection.cs
@@ -1,4 +1,6 @@
-﻿// PerformanceCollection.cs
+namespace FileSyncServer.Tests;
+
+// PerformanceCollection.cs
 [CollectionDefinition("Performance collection", DisableParallelization = true)]
 public class PerformanceCollection : ICollectionFixture<ServerFixture>
 {

--- a/test/FileSyncServer.Tests/PerformanceTests .cs
+++ b/test/FileSyncServer.Tests/PerformanceTests .cs
@@ -7,10 +7,10 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using FileSyncServer;
 using FluentAssertions;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 using Xunit;
 
-namespace Server
+namespace FileSyncServer.Tests
 {
     [Collection("Performance collection")]
     public class PerformanceTests() : IAsyncLifetime

--- a/test/FileSyncServer.Tests/Remote/BaseTestRemote.cs
+++ b/test/FileSyncServer.Tests/Remote/BaseTestRemote.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests.Remote
 {
     [Collection("RemoteBlazorWpf Collection")]
     public abstract class BaseTestRemote<T>(ITestOutputHelper output) : IAsyncLifetime where T : BaseTestRemoteFixture, new()

--- a/test/FileSyncServer.Tests/Remote/BaseTestRemoteFixture.cs
+++ b/test/FileSyncServer.Tests/Remote/BaseTestRemoteFixture.cs
@@ -13,7 +13,7 @@ using Xunit;
 using PeakSWC.RemoteWebView;
 using Grpc.Net.Client.Web;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests.Remote
 {
     public class BaseTestRemoteFixture : IAsyncLifetime, IDisposable
     {
@@ -94,6 +94,7 @@ namespace WebdriverTestProject
         {
             // Ensure cleanup is called
             Cleanup();
+            GC.SuppressFinalize(this);
         }
 
         public async Task Startup(int numClients)

--- a/test/FileSyncServer.Tests/Remote/TestRemote.cs
+++ b/test/FileSyncServer.Tests/Remote/TestRemote.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests.Remote
 {
     #region WPF
     [Collection("TestRemoteBlazorWpf")]

--- a/test/FileSyncServer.Tests/Remote/TestServerForm.cs
+++ b/test/FileSyncServer.Tests/Remote/TestServerForm.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests.Remote
 {
     public class TestServerForm(ITestOutputHelper output) : TestRemoteBlazorForm(output)
     {

--- a/test/FileSyncServer.Tests/Remote/TestServerWpf.cs
+++ b/test/FileSyncServer.Tests/Remote/TestServerWpf.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests.Remote
 {
     public class TestServerWpf(ITestOutputHelper output) : TestRemoteBlazorWpf(output)
     {

--- a/test/FileSyncServer.Tests/ServerCaching.cs
+++ b/test/FileSyncServer.Tests/ServerCaching.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 using System.Diagnostics;
 using System.Net;
 using System.Security.Principal;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 
 namespace FileSyncServer.Tests
 {
@@ -120,6 +120,7 @@ namespace FileSyncServer.Tests
                     // Log the exception or handle accordingly
                 }
             }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/FileSyncServer.Tests/ServerCachingCollection.cs
+++ b/test/FileSyncServer.Tests/ServerCachingCollection.cs
@@ -1,4 +1,6 @@
-﻿[CollectionDefinition("Server caching collection", DisableParallelization = true)]
+namespace FileSyncServer.Tests;
+
+[CollectionDefinition("Server caching collection", DisableParallelization = true)]
 public class ServerCachingCollection : ICollectionFixture<ServerFixture>, ICollectionFixture<ClientFixture>
 {
     // This class has no code, and is never created. Its purpose is simply

--- a/test/FileSyncServer.Tests/ServerCollection.cs
+++ b/test/FileSyncServer.Tests/ServerCollection.cs
@@ -1,4 +1,6 @@
-﻿[CollectionDefinition("Server collection", DisableParallelization = true)]
+namespace FileSyncServer.Tests;
+
+[CollectionDefinition("Server collection", DisableParallelization = true)]
 public class ServerCollection : ICollectionFixture<ServerFixture>, ICollectionFixture<ClientFixture>
 {
     // This class has no code, and is never created. Its purpose is simply

--- a/test/FileSyncServer.Tests/ServerFixture.cs
+++ b/test/FileSyncServer.Tests/ServerFixture.cs
@@ -1,8 +1,10 @@
 ﻿using System.Diagnostics;
 
 using FileSyncServer;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 
+namespace FileSyncServer.Tests
+{
 public class ServerFixture : IDisposable
 {
     public Process ServerProcess { get; private set; }
@@ -92,5 +94,7 @@ public class ServerFixture : IDisposable
         }
         ServerProcess.Dispose();
         _serverReady.Dispose();
+        GC.SuppressFinalize(this);
     }
+}
 }

--- a/test/FileSyncServer.Tests/TestBlazorFormControl.cs
+++ b/test/FileSyncServer.Tests/TestBlazorFormControl.cs
@@ -16,7 +16,7 @@ using PeakSWC.RemoteWebView;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public class TestBlazorFormControl : IClassFixture<TestBlazorFormControlFixture>
     {

--- a/test/FileSyncServer.Tests/TestBlazorFormControlFixture.cs
+++ b/test/FileSyncServer.Tests/TestBlazorFormControlFixture.cs
@@ -13,7 +13,7 @@ using PeakSWC.RemoteWebView;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public class TestBlazorFormControlFixture : IAsyncLifetime
     {
@@ -75,6 +75,7 @@ namespace WebdriverTestProject
         {
             BlazorWebViewFormFactory.Shutdown();
             Process?.Kill();
+            GC.SuppressFinalize(this);
         }
 
         // Synchronous Dispose for IAsyncLifetime

--- a/test/FileSyncServer.Tests/TestBlazorWpfControl.cs
+++ b/test/FileSyncServer.Tests/TestBlazorWpfControl.cs
@@ -11,7 +11,7 @@ using PeakSWC.RemoteWebView;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public class TestBlazorWpfControl : IClassFixture<TestBlazorWpfControlFixture>
     {

--- a/test/FileSyncServer.Tests/TestBlazorWpfControlFixture.cs
+++ b/test/FileSyncServer.Tests/TestBlazorWpfControlFixture.cs
@@ -12,7 +12,7 @@ using PeakSWC.RemoteBlazorWebView.Wpf;
 using PeakSWC.RemoteWebView;
 using Xunit;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     // Fixture class for setup and teardown
     public class TestBlazorWpfControlFixture : IAsyncLifetime

--- a/test/FileSyncServer.Tests/TestMisc.cs
+++ b/test/FileSyncServer.Tests/TestMisc.cs
@@ -1,6 +1,6 @@
 ﻿
 using Xunit.Abstractions;
-using WebdriverTestProject;
+using FileSyncServer.Tests;
 
 namespace FileSyncServer.Tests
 {

--- a/test/FileSyncServer.Tests/Utilities.cs
+++ b/test/FileSyncServer.Tests/Utilities.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.IO.Compression;
 
-namespace WebdriverTestProject
+namespace FileSyncServer.Tests
 {
     public static class Utilities
     {


### PR DESCRIPTION
## Summary
- match namespaces to folder structure in test project
- wrap fixture/helper classes in proper namespace
- call `GC.SuppressFinalize` in disposers

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbdbb56988320b186a2e9d8562303