### PR TITLE
Fix warnings for remote static files

### DIFF
--- a/src/RemoteWebViewService/EndPoints/Mirror.cs
+++ b/src/RemoteWebViewService/EndPoints/Mirror.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
+using PeakSWC.RemoteWebView.RemoteStaticFiles;
 using System;
 using System.Collections.Concurrent;
 using System.IO;

--- a/src/RemoteWebViewService/EndPoints/StartOrRefresh.cs
+++ b/src/RemoteWebViewService/EndPoints/StartOrRefresh.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using PeakSWC.RemoteWebView.Pages;
 using PeakSWC.RemoteWebView.Services;
+using PeakSWC.RemoteWebView.RemoteStaticFiles;
 using System;
 using System.Collections.Concurrent;
 using System.IO;

--- a/src/RemoteWebViewService/RemoteStaticFiles/FileStats.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/FileStats.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading;
 
-namespace PeakSWC.RemoteWebView
+namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public class FileStats
     {

--- a/src/RemoteWebViewService/RemoteStaticFiles/FileStream.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/FileStream.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Net;
 
-namespace PeakSWC.RemoteWebView
+namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public class FileStream
     {

--- a/src/RemoteWebViewService/RemoteStaticFiles/RemoteFileResolver.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/RemoteFileResolver.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-namespace PeakSWC.RemoteWebView
+namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public partial class RemoteFileResolver(ILogger<RemoteFileResolver> logger, ServerFileSyncManager manager)
     {

--- a/src/RemoteWebViewService/RemoteStaticFiles/RemoteFilesMiddleware.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/RemoteFilesMiddleware.cs
@@ -11,7 +11,7 @@ using System;
 using System.Linq;
 using System.Collections.Concurrent;
 
-namespace PeakSWC.RemoteWebView
+namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public class RemoteFilesMiddleware(
         RequestDelegate next,
@@ -225,21 +225,19 @@ namespace PeakSWC.RemoteWebView
                 if (options.UseServerCache)
                 {
                     // Optionally cache the data
-                    using (var memStream = new MemoryStream())
-                    {
-                        await dataRequest.Stream.CopyToAsync(memStream).ConfigureAwait(false);
-                        memStream.Position = 0;
+                    using MemoryStream memStream = new();
+                    await dataRequest.Stream.CopyToAsync(memStream).ConfigureAwait(false);
+                    memStream.Position = 0;
 
-                        // Update metadata in cache
-                        memoryCache.Set(subPath, clientMetadata, TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
+                    // Update metadata in cache
+                    memoryCache.Set(subPath, clientMetadata, TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
 
-                        // Cache the data
-                        memoryCache.Set($"{subPath}_data", memStream.ToArray(), TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
+                    // Cache the data
+                    memoryCache.Set($"{subPath}_data", memStream.ToArray(), TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
 
-                        // Write the data to the response
-                        memStream.Position = 0;
-                        await memStream.CopyToAsync(context.Response.Body).ConfigureAwait(false);
-                    }
+                    // Write the data to the response
+                    memStream.Position = 0;
+                    await memStream.CopyToAsync(context.Response.Body).ConfigureAwait(false);
                 }
                 else
                 {
@@ -279,22 +277,20 @@ namespace PeakSWC.RemoteWebView
                     // Optionally cache the data
                     if (options.UseServerCache)
                     {
-                        using (var memStream = new MemoryStream())
-                        {
-                            await dataRequest.Stream.CopyToAsync(memStream).ConfigureAwait(false);
-                            memStream.Position = 0;
+                        using MemoryStream memStream = new();
+                        await dataRequest.Stream.CopyToAsync(memStream).ConfigureAwait(false);
+                        memStream.Position = 0;
 
-                            // Update metadata in cache
-                            memoryCache.Set(subPath, clientMetadata, TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
+                        // Update metadata in cache
+                        memoryCache.Set(subPath, clientMetadata, TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
 
-                            // Cache the data
-                            memoryCache.Set($"{subPath}_data", memStream.ToArray(), TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
+                        // Cache the data
+                        memoryCache.Set($"{subPath}_data", memStream.ToArray(), TimeSpan.FromSeconds(fileSyncManager.CacheTimeoutSeconds));
 
-                            // Write the data to the response
-                            memStream.Position = 0;
-                            context.Response.ContentLength = memStream.Length;
-                            await memStream.CopyToAsync(context.Response.Body).ConfigureAwait(false);
-                        }
+                        // Write the data to the response
+                        memStream.Position = 0;
+                        context.Response.ContentLength = memStream.Length;
+                        await memStream.CopyToAsync(context.Response.Body).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/RemoteWebViewService/RemoteStaticFiles/RemoteFilesMiddlewareExtensions.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/RemoteFilesMiddlewareExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using System;
 
-namespace PeakSWC.RemoteWebView
+namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public static class RemoteFilesMiddlewareExtensions
     {

--- a/src/RemoteWebViewService/RemoteStaticFiles/RemoteFilesOptions.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/RemoteFilesOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PeakSWC.RemoteWebView
+﻿namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public class RemoteFilesOptions
     {

--- a/src/RemoteWebViewService/RemoteStaticFiles/ServerFileSyncManager.cs
+++ b/src/RemoteWebViewService/RemoteStaticFiles/ServerFileSyncManager.cs
@@ -11,7 +11,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Channel = System.Threading.Channels.Channel;
 
-namespace PeakSWC.RemoteWebView
+namespace PeakSWC.RemoteWebView.RemoteStaticFiles
 {
     public class ServerFileSyncManager : IDisposable
     {

--- a/src/RemoteWebViewService/Services/ClientIPCService.cs
+++ b/src/RemoteWebViewService/Services/ClientIPCService.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using PeakSWC.RemoteWebView.RemoteStaticFiles;
 
 namespace PeakSWC.RemoteWebView
 {

--- a/src/RemoteWebViewService/Services/RemoteWebViewService.cs
+++ b/src/RemoteWebViewService/Services/RemoteWebViewService.cs
@@ -2,6 +2,7 @@ using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using PeakSWC.RemoteWebView.Services;
+using PeakSWC.RemoteWebView.RemoteStaticFiles;
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;


### PR DESCRIPTION
## Summary
- correct namespace declarations in `RemoteStaticFiles` classes
- update references to the new namespace
- simplify two `using` statements in `RemoteFilesMiddleware`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbf2023288320a1e804050bb4bd9b