### PR TITLE
Fix analyzer warnings

### DIFF
--- a/src/Benchmarks/ClientBenchmark/Program.cs
+++ b/src/Benchmarks/ClientBenchmark/Program.cs
@@ -381,14 +381,14 @@ namespace ClientBenchmark
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30000));  // shutdown waiting 20 seconds for tasks to cancel
             var response = _client.CreateWebView(new CreateWebViewRequest { Id = id, EnableMirrors=false, HtmlHostPath="wwwroot/index.html" }, null,null, cts.Token);
 
-            var wrapper = new HttpClientWrapper(httpClient);
+            HttpClientWrapper wrapper = new(httpClient);
             try
             {
                 foreach (var message in response.ResponseStream.ReadAllAsync(/*cts.Token*/).ToBlockingEnumerable())
                 {
                     if (message.Response == "created:")
                     {
-                        ClientFileSyncManager  clientFileSyncManager = new ClientFileSyncManager(_client, Guid.Parse(id), "index.html", new PhysicalFileProvider(_rootDirectory + "/wwwroot"), (x) => { }, logger);
+                        ClientFileSyncManager  clientFileSyncManager = new(_client, Guid.Parse(id), "index.html", new PhysicalFileProvider(_rootDirectory + "/wwwroot"), (x) => { }, logger);
                         clientFileSyncManager.HandleServerRequests(cts.Token);
                       
 
@@ -447,14 +447,14 @@ namespace ClientBenchmark
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30000));  // shutdown waiting 20 seconds for tasks to cancel
             var response = _client.CreateWebView(new CreateWebViewRequest { Id = id, EnableMirrors = false, HtmlHostPath = "wwwroot/index.html" }, null, null, cts.Token);
             var messageId = 0;
-            var wrapper = new HttpClientWrapper(httpClient);
+            HttpClientWrapper wrapper = new(httpClient);
             try
             {
                 foreach (var message in response.ResponseStream.ReadAllAsync(/*cts.Token*/).ToBlockingEnumerable())
                 {
                     if (message.Response == "created:")
                     {
-                        ClientFileSyncManager clientFileSyncManager = new ClientFileSyncManager(_client, Guid.Parse(id), "index.html", new PhysicalFileProvider(_rootDirectory + "/wwwroot"), (x) => { }, logger);
+                        ClientFileSyncManager clientFileSyncManager = new(_client, Guid.Parse(id), "index.html", new PhysicalFileProvider(_rootDirectory + "/wwwroot"), (x) => { }, logger);
                         clientFileSyncManager.HandleServerRequests(cts.Token);
 
 
@@ -535,14 +535,14 @@ namespace ClientBenchmark
         }
 
 #if DEBUG
-        public static  void Main(string[] args) { 
+        public static  void Main(string[] _) {
         //public static async Task Main(string[] args) { 
             BenchmarkSwitcher.FromAssembly(typeof(ClientBenchmarks).Assembly).Run(args, new DebugInProcessConfig());
         }
 #else
         // public static async Task Main(string[] args)
        
-        public static void Main(string[] args)
+        public static void Main(string[] _)
         {
             var config = ManualConfig.Create(DefaultConfig.Instance)
                .WithOptions(ConfigOptions.DisableOptimizationsValidator);

--- a/src/EditWebView/Utility.cs
+++ b/src/EditWebView/Utility.cs
@@ -187,13 +187,12 @@ namespace EditWebView
                 using var repo = new Repository(repoPath);
                 var status = repo.RetrieveStatus();
 
-                return status.Modified
+                return [.. status.Modified
                     .Concat(status.Staged)
                     .Concat(status.Untracked)
                     .Concat(status.Missing)
                     .Select(entry => entry.FilePath)
-                    .Distinct()
-                    .ToList();
+                    .Distinct()];
             }
             catch (RepositoryNotFoundException)
             {

--- a/test/FileSyncServer.Tests/BlazorWebViewFactory.cs
+++ b/test/FileSyncServer.Tests/BlazorWebViewFactory.cs
@@ -16,10 +16,10 @@ namespace WebdriverTestProject
     public static class BlazorWebViewFactory
     {
         private static Thread? staThread;
-        private static AutoResetEvent threadInitialized = new AutoResetEvent(false);
-        private static readonly AutoResetEvent threadShutdown = new AutoResetEvent(false);
+        private static AutoResetEvent threadInitialized = new(false);
+        private static readonly AutoResetEvent threadShutdown = new(false);
         public static Window? Window { get; set; } = null;
-        private static Grid? gridContainer = null;
+        private static readonly Grid? gridContainer = null;
 
         public static async Task<BlazorWebView?> CreateBlazorComponent(RootComponent rootComponent)
         {

--- a/test/FileSyncServer.Tests/BlazorWebViewFormFactory.cs
+++ b/test/FileSyncServer.Tests/BlazorWebViewFormFactory.cs
@@ -15,8 +15,8 @@ namespace WebdriverTestProject
     public static class BlazorWebViewFormFactory
     {
         private static Thread? staThread;
-        private static AutoResetEvent threadInitialized = new AutoResetEvent(false);
-        private static readonly AutoResetEvent threadShutdown = new AutoResetEvent(false);
+        private static AutoResetEvent threadInitialized = new(false);
+        private static readonly AutoResetEvent threadShutdown = new(false);
         public static Form? MainForm { get; set; } = null;
 
         public static BlazorWebView? CreateBlazorComponent(RootComponent rootComponent)

--- a/test/FileSyncServer.Tests/Utilities.cs
+++ b/test/FileSyncServer.Tests/Utilities.cs
@@ -18,7 +18,7 @@ using System.IO.Compression;
 
 namespace WebdriverTestProject
 {
-    public static class Utilities
+    public static partial class Utilities
     {
         #region Server
 
@@ -328,12 +328,15 @@ namespace WebdriverTestProject
 
         #region Javascript
 
+        [GeneratedRegex(@"^script\d+\.js$", RegexOptions.IgnoreCase)]
+        private static partial Regex JsFileRegex();
+
         public static void DeleteGeneratedJsFiles(string directoryPath)
         {
             try
             {
                 string[] jsFiles = Directory.GetFiles(directoryPath, "*.js");
-                Regex filePattern = new Regex(@"^script\d+\.js$", RegexOptions.IgnoreCase);
+                Regex filePattern = JsFileRegex();
 
                 foreach (string file in jsFiles)
                 {
@@ -407,9 +410,8 @@ namespace WebdriverTestProject
 
         static string CalculateChecksum(string input)
         {
-            using SHA256 sha256Hash = SHA256.Create();
-            byte[] data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(input));
-            StringBuilder sBuilder = new StringBuilder();
+            byte[] data = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+            StringBuilder sBuilder = new();
             for (int i = 0; i < data.Length; i++)
             {
                 sBuilder.Append(data[i].ToString("x2"));
@@ -543,7 +545,7 @@ namespace WebdriverTestProject
             using var channel = GrpcChannel.ForAddress(BASE_URL, new GrpcChannelOptions { HttpHandler = httpHandler });
             var client = new WebViewIPC.WebViewIPCClient(channel);
             var ids = await client.GetIdsAsync(new Empty());
-            return ids.Responses.ToList();
+            return [..ids.Responses];
         }
 
         public static async Task SetServerCache(bool isEnabled)
@@ -964,7 +966,7 @@ namespace WebdriverTestProject
 
             Console.WriteLine($"Killing {existingProcesses.Length} instance(s) of process: {processName}");
 
-            List<Task> killTasks = existingProcesses.Select(async process =>
+            List<Task> killTasks = [.. existingProcesses.Select(async process =>
             {
                 try
                 {
@@ -986,7 +988,7 @@ namespace WebdriverTestProject
                 {
                     Console.WriteLine($"Failed to kill process {process.ProcessName} (ID: {process.Id}): {ex.Message}");
                 }
-            }).ToList();
+            })];
 
             await Task.WhenAll(killTasks);
         }


### PR DESCRIPTION
## Summary
- use discard parameter to silence unused `args` warning
- apply target-typed `new` in benchmarks and factories
- generate regex at compile time
- simplify checksum hash generation
- use collection expressions instead of `ToList`

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2fa622883209f1d8cb091c02cbf