### PR TITLE
Fix WindowsBase assembly version conflicts

### DIFF
--- a/src/RemoteBlazorWebView.WinForms/RemoteBlazorWebView.WindowsForms.csproj
+++ b/src/RemoteBlazorWebView.WinForms/RemoteBlazorWebView.WindowsForms.csproj
@@ -29,6 +29,11 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="WindowsFormsCoreWebView2AcceleratorKeyPressedEventArgsWrapper.cs" />
   </ItemGroup>

--- a/src/RemoteBlazorWebView.Wpf/RemoteBlazorWebView.Wpf.csproj
+++ b/src/RemoteBlazorWebView.Wpf/RemoteBlazorWebView.Wpf.csproj
@@ -25,8 +25,13 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/budcribar/RemoteBlazorWebView</PackageProjectUrl>
 		<PackageReleaseNotes>Based on maui 9.0.70 </PackageReleaseNotes>
-		<DebugType>full</DebugType>
-	</PropertyGroup>
+        <DebugType>full</DebugType>
+        </PropertyGroup>
+
+        <PropertyGroup>
+                <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+                <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+        </PropertyGroup>
 
 	<ItemGroup>
 		<Compile Include="..\SharedSource\**\*.cs" Link="SharedSource\%(Filename)%(Extension)" />


### PR DESCRIPTION
## Summary
- enable binding redirect generation in WPF and WinForms projects to resolve `WindowsBase` assembly conflicts

## Testing
- `dotnet build RemoteBlazorWebView.sln -c Release -p:EnableWindowsTargeting=true` *(fails: Restore canceled due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684dc7ec902883208db0ae5ccbc5ef67